### PR TITLE
Update ScreenLockCheckPlugin.java

### DIFF
--- a/android/src/main/java/com/example/screen_lock_check/ScreenLockCheckPlugin.java
+++ b/android/src/main/java/com/example/screen_lock_check/ScreenLockCheckPlugin.java
@@ -14,7 +14,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** ScreenLockCheckPlugin */
 public class ScreenLockCheckPlugin implements FlutterPlugin, MethodCallHandler {


### PR DESCRIPTION
Fix error

import io.flutter.plugin.common.PluginRegistry.Registrar;
                                              ^
  symbol:   class Registrar
  location: interface PluginRegistry
Note: /Users/anomalistudio/Documents/Development/GitHub/screen_lock_check/android/src/main/java/com/example/screen_lock_check/ScreenLockCheckPlugin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 error
